### PR TITLE
disable upload md5 check for s3 kms uploads like sse-c

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -976,6 +976,11 @@ class Key(object):
             # object.
             server_side_encryption_customer_algorithm = response.getheader(
                 'x-amz-server-side-encryption-customer-algorithm', None)
+            # check for kms headers, their ETag also doesn't match
+            if server_side_encryption_customer_algorithm is None:
+                server_side_encryption_customer_algorithm = response.getheader(
+                'x-amz-server-side-encryption-aws-kms-key-id', None)
+
             if server_side_encryption_customer_algorithm is None:
                 if self.etag != '"%s"' % md5:
                     raise provider.storage_data_error(

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -978,10 +978,11 @@ class Key(object):
                 'x-amz-server-side-encryption-customer-algorithm', None)
             # check for kms headers, their ETag also doesn't match
             if server_side_encryption_customer_algorithm is None:
-                server_side_encryption_customer_algorithm = response.getheader(
+                server_side_encryption_kms_key = response.getheader(
                 'x-amz-server-side-encryption-aws-kms-key-id', None)
 
-            if server_side_encryption_customer_algorithm is None:
+            if server_side_encryption_customer_algorithm is None\
+            and server_side_encryption_kms_key is None:
                 if self.etag != '"%s"' % md5:
                     raise provider.storage_data_error(
                         'ETag from S3 did not match computed MD5. '


### PR DESCRIPTION
Now that v4 signatures are fixed, when the KMS encryption headers are also set on an S3 upload, the md5 checksum won't match, just like sse-c uploads. This adds the header check to skip the md5 check the same way sse-c uploads do.
